### PR TITLE
Add i18n to default map

### DIFF
--- a/src/blocks/MapBlock.php
+++ b/src/blocks/MapBlock.php
@@ -124,6 +124,15 @@ final class MapBlock extends BaseBootstrap3Block
      */
     public function admin()
     {
-        return '{% if vars.address is not empty %}<div class="iframe-container"><iframe src="{% if cfgs.snazzymapsUrl %}{{ cfgs.snazzymapsUrl }}{% else %}http://maps.google.com/maps?f=q&source=s_q&hl=de&geocode=&q={{ extras.address }}&z={{ extras.zoom }}&t={{ extras.maptype }}&output=embed{% endif %}"></iframe></div>{% else %}<span class="block__empty-text">' . Module::t('block_map_no_content') . '</span>{% endif %}';
+        $language = Yii::$app->composition['langShortCode'];
+        return <<<EOT
+          {% if vars.address is not empty %}
+            <div class="iframe-container">
+              <iframe src="{% if cfgs.snazzymapsUrl %}{{ cfgs.snazzymapsUrl }}{% else %}http://maps.google.com/maps?f=q&source=s_q&hl={$language}&geocode=&q={{ extras.address }}&z={{ extras.zoom }}&t={{ extras.maptype }}&output=embed{% endif %}"></iframe>
+            </div>
+          {% else %}
+            <span class="block__empty-text">' . Module::t('block_map_no_content') . '</span>
+          {% endif %}
+EOT;
     }
 }

--- a/src/blocks/MapBlock.php
+++ b/src/blocks/MapBlock.php
@@ -2,6 +2,7 @@
 
 namespace luya\bootstrap3\blocks;
 
+use Yii;
 use luya\bootstrap3\Module;
 use luya\bootstrap3\BaseBootstrap3Block;
 use luya\bootstrap3\blockgroups\Bootstrap3Group;

--- a/src/views/blocks/MapBlock.php
+++ b/src/views/blocks/MapBlock.php
@@ -8,6 +8,6 @@ $identifier = $this->extraValue('identifier', 0);
 ?>
 <?php if (!empty($this->varValue('address'))):?>
     <div class="embed-responsive embed-responsive-16by9">
-            <iframe src="<? if ($this->cfgValue('snazzymapsUrl', false)): ?><?= $this->cfgValue('snazzymapsUrl', '') ?><? else: ?>https://maps.google.com/maps?f=q&source=s_q&hl=de&geocode=&q=<?= $this->extraValue('address');?>&z=<?= $this->extraValue('zoom');?>&t=<?= $this->extraValue('maptype')?>&output=embed<? endif; ?>" width="600" height="450" frameborder="0" style="border:0"></iframe>
+            <iframe src="<? if ($this->cfgValue('snazzymapsUrl', false)): ?><?= $this->cfgValue('snazzymapsUrl', '') ?><? else: ?>https://maps.google.com/maps?f=q&source=s_q&hl=<?= \Yii::$app->composition['langShortCode']; ?>&geocode=&q=<?= $this->extraValue('address');?>&z=<?= $this->extraValue('zoom');?>&t=<?= $this->extraValue('maptype')?>&output=embed<? endif; ?>" width="600" height="450" frameborder="0" style="border:0"></iframe>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
I guess it is good to use another languages instead of fixed 'de' for the default map.

I'm not definitely sure if composition language is ok for the block view.

--

Set Google maps language to current compostion language instead of fixed 'de'.